### PR TITLE
Add OLED display support option for ESP32 OLED Boards

### DIFF
--- a/lib/CONFIG/config.cpp
+++ b/lib/CONFIG/config.cpp
@@ -148,6 +148,63 @@ char* Config::getPassword() {
     return conf.password;
 }
 
+char* Config::getPilotName() {
+    return conf.pilotName;
+}
+
+const char* Config::getFrequencyName() {
+    switch(conf.frequency) {
+        case 5658: return "Race 1";
+        case 5695: return "Race 2";
+        case 5732: return "Race 3";
+        case 5769: return "Race 4";
+        case 5806: return "Race 5";
+        case 5843: return "Race 6";
+        case 5880: return "Race 7";
+        case 5917: return "Race 8";
+        case 5865: return "Boscam A 1";
+        case 5845: return "Boscam A 2";
+        case 5825: return "Boscam A 3";
+        case 5805: return "Boscam A 4";
+        case 5785: return "Boscam A 5";
+        case 5765: return "Boscam A 6";
+        case 5745: return "Boscam A 7";
+        case 5725: return "Boscam A 8";
+        case 5733: return "Boscam B 1";
+        case 5752: return "Boscam B 2";
+        case 5771: return "Boscam B 3";
+        case 5790: return "Boscam B 4";
+        case 5809: return "Boscam B 5";
+        case 5828: return "Boscam B 6";
+        case 5847: return "Boscam B 7";
+        case 5866: return "Boscam B 8";
+        case 5705: return "Boscam C 1";
+        case 5685: return "Boscam C 2";
+        case 5665: return "Boscam C 3";
+        case 5645: return "Boscam C 4";
+        case 5885: return "Boscam C 5";
+        case 5905: return "Boscam C 6";
+        case 5925: return "Boscam C 7";
+        case 5945: return "Boscam C 8";
+        case 5740: return "Fatshark 1";
+        case 5760: return "Fatshark 2";
+        case 5780: return "Fatshark 3";
+        case 5800: return "Fatshark 4";
+        case 5820: return "Fatshark 5";
+        case 5840: return "Fatshark 6";
+        case 5860: return "Fatshark 7";
+        case 5333: return "LowBand 1";
+        case 5373: return "LowBand 2";
+        case 5413: return "LowBand 3";
+        case 5453: return "LowBand 4";
+        case 5493: return "LowBand 5";
+        case 5533: return "LowBand 6";
+        case 5573: return "LowBand 7";
+        case 5613: return "LowBand 8";
+        default: return "Unknown";
+    }
+}
+
 void Config::setDefaults(void) {
     DEBUG("Setting EEPROM defaults\n");
     // Reset everything to 0/false and then just set anything that zero is not appropriate

--- a/lib/CONFIG/config.h
+++ b/lib/CONFIG/config.h
@@ -35,7 +35,7 @@
 //ESP32
 #else
 
-#define PIN_LED 21
+#define PIN_LED 16 //was 21
 #define PIN_VBAT 35
 #define VBAT_SCALE 2
 #define VBAT_ADD 2
@@ -87,6 +87,8 @@ class Config {
     uint8_t getExitRssi();
     char* getSsid();
     char* getPassword();
+    char* getPilotName();
+    const char* getFrequencyName();
 
    private:
     laptimer_config_t conf;

--- a/lib/LAPTIMER/laptimer.cpp
+++ b/lib/LAPTIMER/laptimer.cpp
@@ -118,3 +118,10 @@ uint32_t LapTimer::getLapTime() {
 bool LapTimer::isLapAvailable() {
     return lapAvailable;
 }
+
+uint32_t LapTimer::getLastLapTime() {
+    if (lapCount == 0) {
+        return 0;
+    }
+    return lapTimes[(lapCount - 1) % LAPTIMER_LAP_HISTORY];
+}

--- a/lib/LAPTIMER/laptimer.h
+++ b/lib/LAPTIMER/laptimer.h
@@ -22,6 +22,7 @@ class LapTimer {
     uint8_t getRssi();
     uint32_t getLapTime();
     bool isLapAvailable();
+    uint32_t getLastLapTime();
 
    private:
     laptimer_state_e state = STOPPED;

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,58 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-extra_configs =
+extra_configs = 
 	targets/PhobosLT.ini
 	targets/ESP32C3.ini
 	targets/LicardoTimer.ini
+upload_port = COM3
+
+[env:PhobosLT]
+framework = arduino
+platform = espressif32@5.2.0
+board = esp32dev
+upload_speed = 460800
+monitor_speed = 460800
+upload_resetmethod = nodemcu
+board_build.f_cpu = 240000000L
+lib_deps = 
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
+	bblanchon/ArduinoJson @ 6.19.4
+	esphome/AsyncTCP-esphome @ 2.0.1
+
+[env:PhobosLT-OLED]
+framework = arduino
+platform = espressif32@5.2.0
+board = esp32dev
+upload_speed = 460800
+monitor_speed = 460800
+upload_resetmethod = nodemcu
+board_build.f_cpu = 240000000L
+lib_deps = 
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
+	bblanchon/ArduinoJson @ 6.19.4
+	esphome/AsyncTCP-esphome @ 2.0.1
+	adafruit/Adafruit GFX Library@^1.11.10
+	adafruit/Adafruit SSD1306@^2.5.11
+build_flags = -D ESP32_OLED=1
+
+[env:ESP32C3]
+framework = arduino
+platform = espressif32@5.2.0
+board = esp32-c3-devkitm-1
+upload_speed = 460800
+monitor_speed = 460800
+upload_resetmethod = nodemcu
+lib_deps = 
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
+	bblanchon/ArduinoJson @ 6.19.4
+	esphome/AsyncTCP-esphome @ 2.0.1
+platform_packages = 
+	toolchain-riscv32-esp @ 8.4.0+2021r2-patch5
+build_flags = -D ESP32C3=1
+
+[env:LicardoTimer]
+extends = env:ESP32C3
+lib_deps = 
+	adafruit/Adafruit GFX Library@^1.11.10
+	adafruit/Adafruit SSD1306@^2.5.11

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,12 @@
 #include "led.h"
 #include "webserver.h"
 
+#ifdef ESP32_OLED
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#endif
+
 static RX5808 rx(PIN_RX5808_RSSI, PIN_RX5808_DATA, PIN_RX5808_SELECT, PIN_RX5808_CLOCK);
 static Config config;
 static Webserver ws;
@@ -10,7 +16,15 @@ static Led led;
 static LapTimer timer;
 static BatteryMonitor monitor;
 
+#ifdef ESP32_OLED
+static Adafruit_SSD1306 display(128, 64, &Wire, -1);
+#endif
+
 static TaskHandle_t xTimerTask = NULL;
+
+#ifdef ESP32_OLED
+static TaskHandle_t xDisplayTask = NULL;
+#endif
 
 static void parallelTask(void *pvArgs) {
     for (;;) {
@@ -29,18 +43,67 @@ static void initParallelTask() {
     xTaskCreatePinnedToCore(parallelTask, "parallelTask", 3000, NULL, 0, &xTimerTask, 0);
 }
 
+#ifdef ESP32_OLED
+static void updateDisplayTask(void *pvArgs) {
+    for (;;) {
+        // Update display
+        display.clearDisplay();
+        display.setCursor(0,0);
+        if (WiFi.getMode() == WIFI_AP) {
+            display.println(WiFi.softAPSSID());
+        } else {
+            display.println("PhobosLT");
+        }
+        display.print("Batt: ");
+        display.print(monitor.getBatteryVoltage() / 10.0);
+        display.println("V");
+        display.println(config.getFrequencyName());
+        display.print(config.getFrequency() / 1000.0, 3);
+        display.println(" GHz");
+        display.print("Pilot: ");
+        display.println(config.getPilotName());
+        display.print("Last Lap: ");
+        display.print(timer.getLastLapTime() / 1000.0);
+        display.println("s");
+        display.display();
+        vTaskDelay(pdMS_TO_TICKS(1000)); // Update display every 100ms
+    }
+}
+
+static void initDisplayTask() {
+    xTaskCreatePinnedToCore(updateDisplayTask, "updateDisplayTask", 3000, NULL, 1, &xDisplayTask, 1);
+}
+#endif
+
 void setup() {
     DEBUG_INIT;
     config.init();
     rx.init();
     buzzer.init(PIN_BUZZER, BUZZER_INVERTED);
-    led.init(PIN_LED, false);
+    led.init(PIN_LED, true); //was false
     timer.init(&config, &rx, &buzzer, &led);
     monitor.init(PIN_VBAT, VBAT_SCALE, VBAT_ADD, &buzzer, &led);
     ws.init(&config, &timer, &monitor, &buzzer, &led);
     led.on(400);
     buzzer.beep(200);
     initParallelTask();
+    
+    #ifdef ESP32_OLED
+    // Initialize OLED display
+    Wire.begin(5, 4);
+    if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+        DEBUG("SSD1306 allocation failed\n");
+    }
+    display.clearDisplay();
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+    display.setCursor(0,0);
+    display.println("PhobosLT");
+    display.display();
+
+    // Start the display update task
+    initDisplayTask();
+    #endif
 }
 
 void loop() {


### PR DESCRIPTION
Add OLED display support option for boards like TTGO ESP32 module with OLED display and 18650 battery holder. 
 See, e.g., https://www.areresearch.net/2018/01/how-to-use-ttgo-esp32-module-with-oled.html

The display shows:
the WiFi SSID
Battery Voltage
Frequency Name
Frequency GHz
Pilot Name
Last Lap Time

This pull request also changes the LED pin to use the built in aux LED on pin 16 on the TTGO board.