### PR TITLE
Refactor webserver to set cache control for static files, and add configurable ASYNC TCP EVENT QUEUE SIZE

### DIFF
--- a/lib/WEBSERVER/webserver.cpp
+++ b/lib/WEBSERVER/webserver.cpp
@@ -322,7 +322,7 @@ Battery Voltage:\t%0.1fv";
         led->on(200);
     });
 
-    server.serveStatic("/", LittleFS, "/");
+    server.serveStatic("/", LittleFS, "/").setCacheControl("max-age=600");
 
     events.onConnect([this](AsyncEventSourceClient *client) {
         if (client->lastId()) {

--- a/targets/ESP32C3.ini
+++ b/targets/ESP32C3.ini
@@ -7,8 +7,9 @@ upload_speed = 460800
 monitor_speed = 460800
 upload_resetmethod = nodemcu
 board_build.f_cpu = 160000000L
-lib_deps = 
-    ottowinter/ESPAsyncWebServer-esphome @ 3.2.2
+lib_deps =
+    https://github.com/mkfrey/AsyncTCP#kconfig_queue_size
+    mathieucarbou/ESPAsyncWebServer@^3.3.17
     bblanchon/ArduinoJson @ 7.2.0
-    esphome/AsyncTCP-esphome @ 2.1.4
-build_flags = -D ESP32C3=1
+
+build_flags = -D ESP32C3=1 -DCONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE=256

--- a/targets/ESP32S3.ini
+++ b/targets/ESP32S3.ini
@@ -7,8 +7,9 @@ upload_speed = 460800
 monitor_speed = 460800
 upload_resetmethod = nodemcu
 board_build.f_cpu = 240000000L
-lib_deps = 
-    ottowinter/ESPAsyncWebServer-esphome @ 3.2.2
+lib_deps =
+    https://github.com/mkfrey/AsyncTCP#kconfig_queue_size
+    mathieucarbou/ESPAsyncWebServer@^3.3.17
     bblanchon/ArduinoJson @ 7.2.0
-    esphome/AsyncTCP-esphome @ 2.1.4
-build_flags = -D ESP32S3=1
+
+build_flags = -D ESP32S3=1 -DCONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE=256

--- a/targets/PhobosLT.ini
+++ b/targets/PhobosLT.ini
@@ -7,7 +7,9 @@ upload_speed = 460800
 monitor_speed = 460800
 upload_resetmethod = nodemcu
 board_build.f_cpu = 240000000L
-lib_deps = 
-    ottowinter/ESPAsyncWebServer-esphome @ 3.2.2
+lib_deps =
+    https://github.com/mkfrey/AsyncTCP#kconfig_queue_size
+    mathieucarbou/ESPAsyncWebServer@^3.3.17
     bblanchon/ArduinoJson @ 7.2.0
-    esphome/AsyncTCP-esphome @ 2.1.4
+
+build_flags = -DCONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE=256


### PR DESCRIPTION
Added cache control to server, to limit sending new data trough it after every refresh, and changed AsyncTCP lib to PR https://github.com/mkfrey/AsyncTCP#kconfig_queue_size that has configurable
ASYNC TCP EVENT QUEUE SIZE.

Added config changes in target files.
With this webserver is stable after multiple refreshes.