### PR TITLE
fix: 50th lap error (off by one) #14

### DIFF
--- a/lib/LAPTIMER/laptimer.cpp
+++ b/lib/LAPTIMER/laptimer.cpp
@@ -108,7 +108,7 @@ uint32_t LapTimer::getLapTime() {
     uint32_t lapTime = 0;
     lapAvailable = false;
     if (lapCount == 0) {
-        lapTime = lapTimes[LAPTIMER_LAP_HISTORY];
+        lapTime = lapTimes[LAPTIMER_LAP_HISTORY - 1];
     } else {
         lapTime = lapTimes[lapCount - 1];
     }


### PR DESCRIPTION
Appears to be an off by one error when trying to access the last lap time in the buffer.