### PR TITLE
Adjustable start delay and countdown timer

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -102,6 +102,17 @@
             <input type="text" id="pname" maxlength="20" />
           </div>
 
+          <div class="settingsRow">
+            <label>Start Delay (5-120s):</label>
+            <input type="range" class="settingsSlider" id="startDelay" min="5" max="120" value="5">
+            <span id="startDelayValue">5</span>
+          </div>
+          <div class="settingsRow">
+            <label>Countdown Beeps (1-10s):</label>
+            <input type="range" class="settingsSlider" id="countdown" min="1" max="10" value="5">
+            <span id="countdownValue">5</span>
+          </div>
+
           <div class="config-item" style="display: none">
             <label for="ssid">WiFi SSID:</label>
             <input type="text" id="ssid" maxlength="32" />

--- a/data/script.js
+++ b/data/script.js
@@ -451,20 +451,44 @@ function doSpeak(obj) {
   $(obj).articulate("rate", announcerRate).articulate('speak');
 }
 
-async function startRace() {
-  //stopRace();
+function startRace() {
   startRaceButton.disabled = true;
   queueSpeak('<p>Starting race</p>');
   const totalDelay = startDelay * 1000;
   const countdownStart = totalDelay - (countdownDuration * 1000);
-  await new Promise(r => setTimeout(r, Math.max(countdownStart, 0)));
-  for(let i = countdownDuration; i > 0; i--) {
-    beep(100, 440, "square");
-    await new Promise(r => setTimeout(r, 1000));
+  const effectiveCountdownStart = Math.max(countdownStart, 0);
+
+  // Schedule "Pilot ready" 3 seconds before countdown starts, if possible.
+  if (effectiveCountdownStart > 3000) {
+    setTimeout(() => {
+      queueSpeak('<p>Pilot ready</p>');
+    }, effectiveCountdownStart - 3000);
   }
-  beep(500, 880, "square");
-  startTimer();
-  stopRaceButton.disabled = false;
+
+  // Start countdown beeps after the calculated delay
+  setTimeout(() => {
+    let remaining = countdownDuration;
+    
+    // Immediately beep for the first countdown tick
+    if (remaining > 0) {
+      beep(100, 440, "square");
+      remaining--;
+    }
+    
+    // Set up an interval for the remaining countdown beeps
+    const countdownInterval = setInterval(() => {
+      if (remaining > 0) {
+        beep(100, 440, "square");
+        remaining--;
+      } else {
+        clearInterval(countdownInterval);
+        // Final beep to signal race start
+        beep(500, 880, "square");
+        startTimer();
+        stopRaceButton.disabled = false;
+      }
+    }, 1000);
+  }, effectiveCountdownStart);
 }
 
 function stopRace() {

--- a/data/script.js
+++ b/data/script.js
@@ -28,6 +28,9 @@ const race = document.getElementById("race");
 const calib = document.getElementById("calib");
 const ota = document.getElementById("ota");
 
+var startDelay = 5;
+var countdownDuration = 5;
+
 var enterRssi = 120,
   exitRssi = 100;
 var frequency = 0;
@@ -285,6 +288,17 @@ function updateAlarmThreshold(obj, value) {
 //   $().articulate("getVoices", "#voiceSelect", "System Default Announcer Voice");
 // }
 
+document.getElementById('startDelay').addEventListener('input', function(e) {
+  startDelay = parseInt(e.target.value);
+  document.getElementById('startDelayValue').textContent = startDelay;
+});
+
+document.getElementById('countdown').addEventListener('input', function(e) {
+  countdownDuration = parseInt(e.target.value);
+  document.getElementById('countdownValue').textContent = countdownDuration;
+});
+
+
 function beep(duration, frequency, type) {
   var context = new AudioContext();
   var oscillator = context.createOscillator();
@@ -440,13 +454,14 @@ function doSpeak(obj) {
 async function startRace() {
   //stopRace();
   startRaceButton.disabled = true;
-  queueSpeak('<p>Starting race in less than five</p>');
-  await new Promise((r) => setTimeout(r, 2000));
-  beep(1, 1, "square"); // needed for some reason to make sure we fire the first beep
-  beep(100, 440, "square");
-  await new Promise((r) => setTimeout(r, 1000));
-  beep(100, 440, "square");
-  await new Promise((r) => setTimeout(r, 1000));
+  queueSpeak('<p>Starting race</p>');
+  const totalDelay = startDelay * 1000;
+  const countdownStart = totalDelay - (countdownDuration * 1000);
+  await new Promise(r => setTimeout(r, Math.max(countdownStart, 0)));
+  for(let i = countdownDuration; i > 0; i--) {
+    beep(100, 440, "square");
+    await new Promise(r => setTimeout(r, 1000));
+  }
   beep(500, 880, "square");
   startTimer();
   stopRaceButton.disabled = false;


### PR DESCRIPTION
added an adjustable start delay slider from 0-120s, and an adjustable countdown beep slider from 0-10s. Could perhaps use a visual countdown clock. The audio and beeps do not seem to be working on iOS. I can not test on Android for lack of device. Works fine on PC. 

Could also add an audio countdown, instead of beeps, or a "ready" audio before the final countdown. If somebody feels compelled to do so. 