### PR TITLE
Reworked the startRace() and its conditions

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -102,6 +102,17 @@
             <input type="text" id="pname" maxlength="20" />
           </div>
 
+          <div class="settingsRow">
+            <label>Start Delay (5-120s):</label>
+            <input type="range" class="settingsSlider" id="startDelay" min="5" max="120" value="5">
+            <span id="startDelayValue">5</span>
+          </div>
+          <div class="settingsRow">
+            <label>Countdown Beeps (1-10s):</label>
+            <input type="range" class="settingsSlider" id="countdown" min="1" max="10" value="5">
+            <span id="countdownValue">5</span>
+          </div>
+
           <div class="config-item" style="display: none">
             <label for="ssid">WiFi SSID:</label>
             <input type="text" id="ssid" maxlength="32" />

--- a/data/script.js
+++ b/data/script.js
@@ -451,20 +451,44 @@ function doSpeak(obj) {
   $(obj).articulate("rate", announcerRate).articulate('speak');
 }
 
-async function startRace() {
-  //stopRace();
+function startRace() {
   startRaceButton.disabled = true;
   queueSpeak('<p>Starting race</p>');
   const totalDelay = startDelay * 1000;
   const countdownStart = totalDelay - (countdownDuration * 1000);
-  await new Promise(r => setTimeout(r, Math.max(countdownStart, 0)));
-  for(let i = countdownDuration; i > 0; i--) {
-    beep(100, 440, "square");
-    await new Promise(r => setTimeout(r, 1000));
+  const effectiveCountdownStart = Math.max(countdownStart, 0);
+
+  // Schedule "Pilot ready" 3 seconds before countdown starts, if possible.
+  if (effectiveCountdownStart > 3000) {
+    setTimeout(() => {
+      queueSpeak('<p>Pilot ready</p>');
+    }, effectiveCountdownStart - 3000);
   }
-  beep(500, 880, "square");
-  startTimer();
-  stopRaceButton.disabled = false;
+
+  // Start countdown beeps after the calculated delay
+  setTimeout(() => {
+    let remaining = countdownDuration;
+    
+    // Immediately beep for the first countdown tick
+    if (remaining > 0) {
+      beep(100, 440, "square");
+      remaining--;
+    }
+    
+    // Set up an interval for the remaining countdown beeps
+    const countdownInterval = setInterval(() => {
+      if (remaining > 0) {
+        beep(100, 440, "square");
+        remaining--;
+      } else {
+        clearInterval(countdownInterval);
+        // Final beep to signal race start
+        beep(500, 880, "square");
+        startTimer();
+        stopRaceButton.disabled = false;
+      }
+    }, 1000);
+  }, effectiveCountdownStart);
 }
 
 function stopRace() {

--- a/data/script.js
+++ b/data/script.js
@@ -457,33 +457,24 @@ function startRace() {
   const totalDelay = startDelay * 1000;
   const countdownStart = totalDelay - (countdownDuration * 1000);
   const effectiveCountdownStart = Math.max(countdownStart, 0);
-
-  // Schedule "Pilot ready" 3 seconds before countdown starts, if possible.
-  if (effectiveCountdownStart > 3000) {
+  if (effectiveCountdownStart > 3000) {                               // Schedule "Pilot ready" 3 seconds before countdown starts, if possible.
     setTimeout(() => {
       queueSpeak('<p>Pilot ready</p>');
     }, effectiveCountdownStart - 3000);
   }
-
-  // Start countdown beeps after the calculated delay
-  setTimeout(() => {
+  setTimeout(() => {                                                  // Start countdown beeps after the calculated delay
     let remaining = countdownDuration;
-    
-    // Immediately beep for the first countdown tick
-    if (remaining > 0) {
+    if (remaining > 0) {                                              // Immediately beep for the first countdown tick
       beep(100, 440, "square");
       remaining--;
     }
-    
-    // Set up an interval for the remaining countdown beeps
-    const countdownInterval = setInterval(() => {
+    const countdownInterval = setInterval(() => {                     // Set up an interval for the remaining countdown beeps
       if (remaining > 0) {
         beep(100, 440, "square");
         remaining--;
       } else {
         clearInterval(countdownInterval);
-        // Final beep to signal race start
-        beep(500, 880, "square");
+        beep(500, 880, "square");                                     // Final beep to signal race start
         startTimer();
         stopRaceButton.disabled = false;
       }

--- a/data/script.js
+++ b/data/script.js
@@ -472,7 +472,8 @@ function startRace() {
       if (remaining > 0) {
         beep(100, 440, "square");
         remaining--;
-      } else {
+      } 
+      else {
         clearInterval(countdownInterval);
         beep(500, 880, "square");                                     // Final beep to signal race start
         startTimer();

--- a/data/script.js
+++ b/data/script.js
@@ -28,6 +28,9 @@ const race = document.getElementById("race");
 const calib = document.getElementById("calib");
 const ota = document.getElementById("ota");
 
+var startDelay = 5;
+var countdownDuration = 5;
+
 var enterRssi = 120,
   exitRssi = 100;
 var frequency = 0;
@@ -285,6 +288,17 @@ function updateAlarmThreshold(obj, value) {
 //   $().articulate("getVoices", "#voiceSelect", "System Default Announcer Voice");
 // }
 
+document.getElementById('startDelay').addEventListener('input', function(e) {
+  startDelay = parseInt(e.target.value);
+  document.getElementById('startDelayValue').textContent = startDelay;
+});
+
+document.getElementById('countdown').addEventListener('input', function(e) {
+  countdownDuration = parseInt(e.target.value);
+  document.getElementById('countdownValue').textContent = countdownDuration;
+});
+
+
 function beep(duration, frequency, type) {
   var context = new AudioContext();
   var oscillator = context.createOscillator();
@@ -440,13 +454,14 @@ function doSpeak(obj) {
 async function startRace() {
   //stopRace();
   startRaceButton.disabled = true;
-  queueSpeak('<p>Starting race in less than five</p>');
-  await new Promise((r) => setTimeout(r, 2000));
-  beep(1, 1, "square"); // needed for some reason to make sure we fire the first beep
-  beep(100, 440, "square");
-  await new Promise((r) => setTimeout(r, 1000));
-  beep(100, 440, "square");
-  await new Promise((r) => setTimeout(r, 1000));
+  queueSpeak('<p>Starting race</p>');
+  const totalDelay = startDelay * 1000;
+  const countdownStart = totalDelay - (countdownDuration * 1000);
+  await new Promise(r => setTimeout(r, Math.max(countdownStart, 0)));
+  for(let i = countdownDuration; i > 0; i--) {
+    beep(100, 440, "square");
+    await new Promise(r => setTimeout(r, 1000));
+  }
   beep(500, 880, "square");
   startTimer();
   stopRaceButton.disabled = false;


### PR DESCRIPTION
Added adjustable sliders for a start delay 0-120s, an adjustable countdown beeper 0-10s, a call-out of "Pilot ready" 3 seconds before the countdown beeps begin if there is time for it, the ability to stop the start delay countdown with the race stop button before the race starts, and reworked the beep() function to only use a single audioContext so as to try and fix the bug where sometimes it will skip or not play the first beep of the countdown beeps. For now, seems as though starting a race once and stopping it after the timer has started, sees it working as it is expected with the countdown beeps. 